### PR TITLE
Fixed spell 'multi_res' that increased unwanted parameters during multi-res training

### DIFF
--- a/training.py
+++ b/training.py
@@ -159,7 +159,7 @@ def train(device, model, dataloaders, save_epoch, step, num_epochs, model_stage,
 
     # fix parameters for training
     for name, p in model.named_parameters():
-        if model_stage == "multires":
+        if model_stage == "multi_res":
             if '_decoder' in name or '_conv_last' in name:
                 p.requires_grad = True
             else:


### PR DESCRIPTION
In the training file, a minor spelling mistake caused the entire network to be trained during the 'multi_res' stage training and it was followed by substandard results. Fixed the same in this commit.